### PR TITLE
Updated SecurityHubEnabler IAM role

### DIFF
--- a/aws-control-tower-securityhub-enabler.template
+++ b/aws-control-tower-securityhub-enabler.template
@@ -161,6 +161,9 @@ Resources:
               - 'securityhub:InviteMembers'
               - 'securityhub:ListInvitations'
               - 'securityhub:ListMembers'
+              - 'securityhub:ListEnabledProductsForImport'
+              - 'securityhub:DisableImportFindingsForProduct'
+              - 'securityhub:EnableImportFindingsForProduct'
             Resource: '*'
     Metadata:
       cfn_nag:


### PR DESCRIPTION
This role will need to be able to enable/disable/list security hub products in order to enable the prowler product