### PR TITLE
Disable CIS benchmark as it will be covered by Prowler

### DIFF
--- a/aws-control-tower-securityhub-enabler.template
+++ b/aws-control-tower-securityhub-enabler.template
@@ -61,7 +61,7 @@ Parameters:
   CISStandard:
     Type: String
     Description: Should Security Hub enable the CIS AWS Foundations Benchmark v1.2.0 Security Standard?
-    Default: "Yes"
+    Default: "No"
     AllowedValues:
       - "Yes"
       - "No"


### PR DESCRIPTION
CIS benchmarks are alreday covered by Prowler in greater extense than AWS's scanner. Therefore we want to disable the AWS scanner as they charge for this service.